### PR TITLE
Fix numpy version networkx==2.4 expects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 networkx==2.4
 paho-mqtt==1.5.0
+numpy==1.20.1
 rhasspy-hermes~=0.6.0
 rhasspy-nlu~=0.3.0


### PR DESCRIPTION
See https://github.com/rhasspy/rhasspy-remote-http-hermes/pull/5 for details